### PR TITLE
fix UpdateFeed xml parsing; fix ErrorCount magic number

### DIFF
--- a/bot/controller.go
+++ b/bot/controller.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/indes/flowerss-bot/bot/fsm"
+	"github.com/indes/flowerss-bot/config"
 	"github.com/indes/flowerss-bot/model"
 	tb "gopkg.in/tucnak/telebot.v2"
 	"html/template"
@@ -92,7 +93,7 @@ func toggleCtrlButtons(c *tb.Callback, action string) {
 		Text:   "暂停更新",
 	}
 
-	if source.ErrorCount >= 100 {
+	if source.ErrorCount >= config.ErrorThreshold {
 		toggleEnabledKey.Text = "重启更新"
 	}
 
@@ -366,7 +367,7 @@ func setFeedItemBtnCtr(c *tb.Callback) {
 		Text:   "暂停更新",
 	}
 
-	if source.ErrorCount >= 100 {
+	if source.ErrorCount >= config.ErrorThreshold {
 		toggleEnabledKey.Text = "重启更新"
 	}
 
@@ -768,7 +769,7 @@ func textCtr(m *tb.Message) {
 					Text:   "暂停更新",
 				}
 
-				if source.ErrorCount >= 100 {
+				if source.ErrorCount >= config.ErrorThreshold {
 					toggleEnabledKey.Text = "重启更新"
 				}
 

--- a/model/subscribe.go
+++ b/model/subscribe.go
@@ -1,6 +1,9 @@
 package model
 
-import "errors"
+import (
+	"errors"
+	"github.com/indes/flowerss-bot/config"
+)
 
 type Subscribe struct {
 	ID                 uint `gorm:"primary_key;AUTO_INCREMENT"`
@@ -190,10 +193,10 @@ func (s *Subscribe) ToggleTelegraph() error {
 }
 
 func (s *Source) ToggleEnabled() error {
-	if s.ErrorCount >= 100 {
+	if s.ErrorCount >= config.ErrorThreshold {
 		s.ErrorCount = 0
 	} else {
-		s.ErrorCount = 100
+		s.ErrorCount = config.ErrorThreshold
 	}
 
 	///TODO a hack for save source changes


### PR DESCRIPTION
last pr did not fix xml parsing for `GetNowContents`. fix that again.
besides some code use magic number `100` instead of `config.ErrorThreshold` when checking `source.ErrorCount`. fix that as well.