### PR TITLE
增加可配置的消息模板

### DIFF
--- a/bot/util.go
+++ b/bot/util.go
@@ -1,0 +1,29 @@
+package bot
+
+import (
+	"regexp"
+	"strings"
+
+	strip "github.com/grokify/html-strip-tags-go"
+)
+
+func trimDescription(desc string, limit int) string {
+	if limit == 0 {
+		return ""
+	}
+	desc = strings.Trim(
+		strip.StripTags(
+			regexp.MustCompile(`\n+`).ReplaceAllLiteralString(
+				strings.ReplaceAll(
+					regexp.MustCompile(`<br(| /)>`).ReplaceAllString(desc, "<br>"),
+					"<br>", "\n"),
+				"\n")),
+		"\n")
+
+	contentDescRune := []rune(desc)
+	if len(contentDescRune) > limit {
+		desc = string(contentDescRune[:limit])
+	}
+
+	return desc
+}

--- a/config/autoload.go
+++ b/config/autoload.go
@@ -1,13 +1,17 @@
 package config
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"github.com/spf13/viper"
+	tb "gopkg.in/tucnak/telebot.v2"
 	"log"
 	"os"
 	"path"
 	"strconv"
+	"strings"
+	"text/template"
 )
 
 var (
@@ -21,6 +25,29 @@ var (
 	EnableMysql     bool
 	UpdateInterval  int  = 10
 	ErrorThreshold  uint = 100
+	MessageTpl      *template.Template
+	MessageMode     tb.ParseMode
+)
+
+const (
+	logo = `
+   __ _                                
+  / _| | _____      _____ _ __ ___ ___ 
+ | |_| |/ _ \ \ /\ / / _ \ '__/ __/ __|
+ |  _| | (_) \ V  V /  __/ |  \__ \__ \
+ |_| |_|\___/ \_/\_/ \___|_|  |___/___/
+
+`
+	defaultMessageTplMode = "md"
+	defaultMessageTpl     = `** {{.SourceTitle}} **{{ if .PreviewText }}
+---------- Preview ----------
+{{.PreviewText}}
+-----------------------------
+{{- end}}{{if .EnableTelegraph}}
+{{.ContentTitle}} [Telegraph]({{.TelegraphURL}}) | [原文]({{.RawLink}})
+{{- else }}
+[{{.ContentTitle}}]({{.RawLink}})
+{{- end }}`
 )
 
 type MysqlConfig struct {
@@ -31,17 +58,83 @@ type MysqlConfig struct {
 	DB       string
 }
 
+type TplData struct {
+	SourceTitle     string
+	ContentTitle    string
+	RawLink         string
+	PreviewText     string
+	TelegraphURL    string
+	EnableTelegraph bool
+}
+
+func validateTPL() {
+	testData := []TplData{
+		TplData{
+			"RSS 源标识 - 无预览无telegraph的消息",
+			"这是标题",
+			"https://www.github.com/",
+			"",
+			"",
+			false,
+		},
+		TplData{
+			"RSS源标识 - 有预览无telegraph的消息",
+			"这是标题",
+			"https://www.github.com/",
+			"这里是很长很长很长的消息预览字数补丁紫薯补丁紫薯补丁紫薯补丁紫薯补丁",
+			"",
+			false,
+		},
+		TplData{
+			"RSS源标识 - 有预览有telegraph的消息",
+			"这是标题",
+			"https://www.github.com/",
+			"这里是很长很长很长的消息预览字数补丁紫薯补丁紫薯补丁紫薯补丁紫薯补丁",
+			"https://telegra.ph/markdown-07-07",
+			true,
+		},
+	}
+
+	var buf []byte
+	w := bytes.NewBuffer(buf)
+
+	for _, d := range testData {
+		w.Reset()
+		fmt.Println("\n////////////////////////////////////////////")
+		if err := MessageTpl.Execute(os.Stdout, d); err != nil {
+			log.Fatal(err)
+		}
+	}
+	fmt.Println("\n////////////////////////////////////////////")
+}
+
+func initTPL() {
+
+	var tplMsg string
+	if viper.IsSet("message_tpl") {
+		tplMsg = viper.GetString("message_tpl")
+	} else {
+		tplMsg = defaultMessageTpl
+	}
+	MessageTpl = template.Must(template.New("message").Parse(tplMsg))
+
+	if viper.IsSet("message_tpl_mode") {
+		switch strings.ToLower(viper.GetString("message_tpl_mode")) {
+		case "md", "markdown":
+			MessageMode = tb.ModeMarkdown
+		case "html":
+			MessageMode = tb.ModeHTML
+		default:
+			MessageMode = tb.ModeDefault
+		}
+	} else {
+		MessageMode = tb.ModeMarkdown
+	}
+
+}
+
 func init() {
 
-	logo := `
-   __ _                                
-  / _| | _____      _____ _ __ ___ ___ 
- | |_| |/ _ \ \ /\ / / _ \ '__/ __/ __|
- |  _| | (_) \ V  V /  __/ |  \__ \__ \
- |_| |_|\___/ \_/\_/ \___|_|  |___/___/
-
-`
-	fmt.Println(logo)
 	telegramTokenCli := flag.String("b", "", "Telegram Bot Token")
 	telegraphTokenCli := flag.String("t", "", "Telegraph API Token")
 	previewTextCli := flag.Int("p", 0, "Preview Text Length")
@@ -49,6 +142,7 @@ func init() {
 	errorThresholdCli := flag.Int("threshold", 0, "Error Threshold")
 	socks5Cli := flag.String("s", "", "Socks5 Proxy")
 	intervalCli := flag.Int("i", 0, "Update Interval")
+	testTpl := flag.Bool("testtpl", false, "Test Template")
 	flag.Parse()
 
 	projectName := "flowerss-bot"
@@ -62,6 +156,14 @@ func init() {
 	if err != nil {             // Handle errors reading the config file
 		panic(fmt.Errorf("Fatal error config file: %s", err))
 	}
+
+	initTPL()
+	if *testTpl {
+		validateTPL()
+		os.Exit(0)
+	}
+
+	fmt.Println(logo)
 
 	if *telegramTokenCli == "" {
 		BotToken = viper.GetString("bot_token")

--- a/config/autoload.go
+++ b/config/autoload.go
@@ -118,8 +118,8 @@ func initTPL() {
 	}
 	MessageTpl = template.Must(template.New("message").Parse(tplMsg))
 
-	if viper.IsSet("message_tpl_mode") {
-		switch strings.ToLower(viper.GetString("message_tpl_mode")) {
+	if viper.IsSet("message_mode") {
+		switch strings.ToLower(viper.GetString("message_mode")) {
 		case "md", "markdown":
 			MessageMode = tb.ModeMarkdown
 		case "html":


### PR DESCRIPTION
## 主要功能

配置文件增加以下可选选项：

配置项 | 含义 | 必填
-- | -- | --
`message_tpl` |推送消息的模板|可忽略
`message_mode`|推送消息的模板语法|可忽略，可选`markdown` / `md`(简写) / `html`

* `message_tpl` 不配置时为默认模板，跟原版完全一致；
* 消息使用Markdown格式，在telegram内有更好的链接预览效果
* 命令行增加`-testtpl`参数，用以测试模板格式。

## 模板内可使用的变量

变量|说明
------------ | -------------
{{.SourceTitle}}|订阅源名称
{{.ContentTitle}}|内容标题
{{.RawLink}}|原文的链接
{{.EnableTelegraph}}|是否启用了telegraph
{{.TelegraphURL}}|telegraph的URL
{{.PreviewText}}|预览的内容

消息模板使用golang标准库，可参考文档[`text/template`](https://golang.org/pkg/text/template/)

## 原版模板配置（Markdown语法）
```yml
message_tpl: |
    ** {{.SourceTitle}} **
    {{ if .PreviewText }}---------- Preview ----------
    {{.PreviewText}}
    -----------------------------{{- end}}
    {{if .EnableTelegraph}}{{.ContentTitle}}[Telegraph]({{.TelegraphURL}}) | [原文]({{.RawLink}})
    {{- else }}[{{.ContentTitle}}]({{.RawLink}}){{- end }}
```
## 简洁模板参考（使用了markdown的\`\`\`标记实现预览）
```yml
message_tpl: >
    ** {{.SourceTitle}} **

    {{ if .PreviewText }}```

    {{.PreviewText}}

    ```{{- end}}

    {{if .EnableTelegraph}}[Telegraph]({{.TelegraphURL}}) | [原文]({{.RawLink}})
    {{- else }}[{{.ContentTitle}}]({{.RawLink}})
    {{- end }}
```

注意yml中的`|`和`>`区别，后者需空一行才换行。可参考[YAML Multiline
](https://yaml-multiline.info/) 

## 实际效果

![image](https://user-images.githubusercontent.com/51714622/70888733-f7186b80-201b-11ea-9b4b-bbff54bbcf4a.png)
