### PR TITLE
BUG：群组和频道收到表情文件引发OPML导入错误

### DIFF
--- a/bot/controller.go
+++ b/bot/controller.go
@@ -805,21 +805,24 @@ func textCtr(m *tb.Message) {
 }
 
 func docCtr(m *tb.Message) {
-
-	if m.FromChannel() {
-		if !UserIsAdminChannel(m.ID, m.Chat) {
-			return
-		}
-	}
 	if m.FromGroup() {
 		if !userIsAdminOfGroup(m.ID, m.Chat) {
 			return
 		}
 	}
 
-	url, _ := B.FileURLByID(m.Document.FileID)
-	opml, err := GetOPMLByURL(url)
+	if m.FromChannel() {
+		if !UserIsAdminChannel(m.ID, m.Chat) {
+			return
+		}
+	}
 
+	url, _ := B.FileURLByID(m.Document.FileID)
+	if !strings.HasSuffix(url, ".opml") {
+		return
+	}
+
+	opml, err := GetOPMLByURL(url)
 	if err != nil {
 		if err.Error() == "fetch opml file error" {
 			_, _ = B.Send(m.Chat,

--- a/bot/controller.go
+++ b/bot/controller.go
@@ -806,6 +806,17 @@ func textCtr(m *tb.Message) {
 
 func docCtr(m *tb.Message) {
 
+	if m.FromChannel() {
+		if !UserIsAdminChannel(m.ID, m.Chat) {
+			return
+		}
+	}
+	if m.FromGroup() {
+		if !userIsAdminOfGroup(m.ID, m.Chat) {
+			return
+		}
+	}
+
 	url, _ := B.FileURLByID(m.Document.FileID)
 	opml, err := GetOPMLByURL(url)
 


### PR DESCRIPTION
BUG：群组和频道收到表情文件引发OPML导入错误，群员发送gif之类的动图表情会触发`docCtr`函数。

添加检测群组成员身份检测以及文件后缀`.opml`检测。