### PR TITLE
decode html entities before publish to telegraph

### DIFF
--- a/tgraph/publish.go
+++ b/tgraph/publish.go
@@ -2,12 +2,13 @@ package tgraph
 
 import (
 	"fmt"
+	"html"
 	"log"
 	"math/rand"
 	"time"
 )
 
-func PublishHtml(sourceTitle string, title string, rawLink string, html string) (string, error) {
+func PublishHtml(sourceTitle string, title string, rawLink string, htmlContent string) (string, error) {
 	//html = fmt.Sprintf(
 	//	"<p>本文章由 <a href=\"https://github.com/indes/flowerss-bot\">flowerss</a> 抓取自RSS，版权归<a href=\"\">源站点</a>所有。</p><hr>",
 	//) + html + fmt.Sprintf(
@@ -17,7 +18,7 @@ func PublishHtml(sourceTitle string, title string, rawLink string, html string) 
 	//	sourceTitle,
 	//)
 
-	html = html + fmt.Sprintf(
+	htmlContent = html.UnescapeString(htmlContent) + fmt.Sprintf(
 		"<hr><p>本文章由 <a href=\"https://github.com/indes/flowerss-bot\">flowerss</a> 抓取自RSS，版权归<a href=\"\">源站点</a>所有。</p><p>查看原文：<a href=\"%s\">%s - %s</p>",
 		rawLink,
 		title,
@@ -26,7 +27,7 @@ func PublishHtml(sourceTitle string, title string, rawLink string, html string) 
 	rand.Seed(time.Now().Unix()) // initialize global pseudo random generator
 	client := clientPool[rand.Intn(len(clientPool))]
 
-	if page, err := client.CreatePageWithHTML(title+" - "+sourceTitle, sourceTitle, rawLink, html, true); err == nil {
+	if page, err := client.CreatePageWithHTML(title+" - "+sourceTitle, sourceTitle, rawLink, htmlContent, true); err == nil {
 		log.Printf("Created telegraph page url: %s", page.URL)
 		return page.URL, err
 	} else {

--- a/tgraph/tgraph.go
+++ b/tgraph/tgraph.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	//verbose = false
-	html = `<h1>hello</h1>`
+	htmlContent = `<h1>hello</h1>`
 )
 
 var (


### PR DESCRIPTION
In some cases, the feeds may contain html entities in its content. unescape them to avoid content format mess up