### PR TITLE
support creating telegrph account when don't have one

### DIFF
--- a/config.yml.sample
+++ b/config.yml.sample
@@ -1,5 +1,8 @@
 bot_token:
 telegraph_token:
+telegraph_account:
+telegraph_author_name:
+telegraph_author_url:
 socks5:
 update_interval: 10
 user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36

--- a/config/autoload.go
+++ b/config/autoload.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"github.com/spf13/viper"
-	tb "gopkg.in/tucnak/telebot.v2"
 	"log"
 	"os"
 	"path"
@@ -14,6 +12,9 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+
+	"github.com/spf13/viper"
+	tb "gopkg.in/tucnak/telebot.v2"
 )
 
 var (
@@ -21,6 +22,9 @@ var (
 	BotToken              string
 	Socks5                string
 	TelegraphToken        []string
+	TelegraphAccountName  string
+	TelegraphAuthorName   string = "flowerss-bot"
+	TelegraphAuthorURL    string
 	EnableTelegraph       bool
 	PreviewText           int = 0
 	DisableWebPagePreview bool
@@ -132,6 +136,19 @@ func init() {
 		TelegraphToken = viper.GetStringSlice("telegraph_token")
 	} else {
 		EnableTelegraph = false
+	}
+
+	if viper.IsSet("telegraph_account") {
+		EnableTelegraph = true
+		TelegraphAccountName = viper.GetString("telegraph_account")
+
+		if viper.IsSet("telegraph_author_name") {
+			TelegraphAuthorName = viper.GetString("telegraph_author_name")
+		}
+
+		if viper.IsSet("telegraph_author_url") {
+			TelegraphAuthorURL = viper.GetString("telegraph_author_url")
+		}
 	}
 
 	if viper.IsSet("preview_text") {

--- a/tgraph/tgraph.go
+++ b/tgraph/tgraph.go
@@ -2,9 +2,10 @@ package tgraph
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/indes/flowerss-bot/config"
 	"github.com/indes/telegraph-go"
-	"log"
 )
 
 const (
@@ -38,8 +39,17 @@ func init() {
 		}
 
 		if len(clientPool) == 0 {
-			config.EnableTelegraph = false
-			log.Println("Telegraph token error, telegraph disabled")
+			if config.TelegraphAccountName == "" {
+				config.EnableTelegraph = false
+				log.Println("Telegraph token error, telegraph disabled")
+			} else if len(authToken) == 0 {
+				// create account
+				if client, err := telegraph.Create(config.TelegraphAccountName, config.TelegraphAuthorName, config.TelegraphAuthorURL, config.Socks5); err != nil {
+					log.Println("create telegraph account fail: ", err)
+				} else {
+					clientPool = append(clientPool, client)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR adds a feature to support that when I don't have a telegraph token, I can create a new telegraph account to publish content