### PR TITLE
支持直接订阅微信公众号，订阅来源 [wechat-feeds](https://github.com/hellodword/wechat-feeds)

### DIFF
--- a/bot/service.go
+++ b/bot/service.go
@@ -68,7 +68,7 @@ func FeedForChannelRegister(m *tb.Message, url string, channelMention string) {
 
 func registFeed(chat *tb.Chat, url string) {
 	msg, err := B.Send(chat, "处理中...")
-
+	url = model.ProcessWechatURL(url)
 	source, err := model.FindOrNewSourceByUrl(url)
 
 	if err != nil {

--- a/model/wechat_feeds.go
+++ b/model/wechat_feeds.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"fmt"
+	"net/url"
+)
+const wechatHost = "mp.weixin.qq.com"
+const wechatSubUrl = "https://github.com/hellodword/wechat-feeds/raw/feeds/%s.xml"
+
+// ProcessWechatURL return wechat-feed sub URL. if it's valid wehchat url, else return origin str
+func ProcessWechatURL(urlStr string) string {
+	u, err := url.Parse(urlStr)
+	if err == nil {
+		if (u.Host == "mp.weixin.qq.com") {
+			q := u.Query()
+			bizs, ok := q["__biz"]
+			if ok {
+				biz := bizs[0]
+				newURL := fmt.Sprintf(wechatSubUrl, biz)
+				return newURL
+			}
+		}
+	}
+	return urlStr
+}

--- a/model/wechat_feeds_test.go
+++ b/model/wechat_feeds_test.go
@@ -1,0 +1,28 @@
+package model
+
+import "testing"
+import "github.com/stretchr/testify/assert"
+
+func Test_ProcessWechatURL(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test normal url
+	urlForSub := "https://github.com/hellodword/wechat-feeds/raw/feeds/Mzg2ODAyNTgyMQ==.xml"
+	res := ProcessWechatURL(urlForSub)
+	assert.Equal(res, urlForSub)
+
+	// Test wechat url with __biz: Success
+	url := "https://mp.weixin.qq.com/s?__biz=Mzg2ODAyNTgyMQ==&mid=2247484843&idx=1&sn=be4445bf3a7520b86d15876d46b7b8ab&chksm=ceb3d119f9c4580f6b360299affd4e2d312a619d32edc2a5e1c031f3a4c600b4b52132d5eb56&scene=132#wechat_redirect"
+	res = ProcessWechatURL(url)
+	assert.Equal(res, urlForSub)
+
+	// Test wechat url without __biz: Like normal url
+	url = "https://mp.weixin.qq.com/s/nGTr26rhHIUJqq6bV8Xwsw"
+	res = ProcessWechatURL(url)
+	assert.Equal(res, url)
+
+	// Test invalid url
+	url = "abcd"
+	res = ProcessWechatURL(url)
+	assert.Equal(res, url)
+}


### PR DESCRIPTION

支持直接订阅微信公众号，订阅来源 [wechat-feeds](https://github.com/hellodword/wechat-feeds)

## 使用方式
只要使用 `/sub ` 带 biz 的公众号链接
例如：`/sub https://mp.weixin.qq.com/s?__biz=Mzg2ODAyNTgyMQ==`

如果 wechat-feeds 已经支持了，就能订阅成功，如果不支持，请先去[提交支持申请](https://github.com/hellodword/wechat-feeds#%E5%A6%82%E4%BD%95%E6%B7%BB%E5%8A%A0%E4%BF%AE%E6%94%B9%E5%85%AC%E4%BC%97%E5%8F%B7)
