### PR TITLE
optimize for big OPML file

### DIFF
--- a/internal/model/subscribe.go
+++ b/internal/model/subscribe.go
@@ -23,6 +23,11 @@ type Subscribe struct {
 	EditTime
 }
 
+type SubWithSource struct {
+	Sub *Subscribe
+	Src *Source
+}
+
 func RegistFeed(userID int64, sourceID uint) error {
 	var subscribe Subscribe
 
@@ -141,7 +146,7 @@ func GetSubByUserIDAndURL(userID int64, url string) (*Subscribe, error) {
 
 func GetSubsByUserID(userID int64) ([]Subscribe, error) {
 	var subs []Subscribe
-	db.Where("user_id=?", userID).Find(&subs)
+	db.Where("user_id=?", userID).Order("id").Find(&subs)
 	return subs, nil
 }
 

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -50,3 +50,32 @@ func (user *User) GetSubSourceMap() (map[Subscribe]Source, error) {
 
 	return m, nil
 }
+
+// GetSubSourceList get user subscribe and fetcher source
+func (user *User) GetSubSourceList() ([]*SubWithSource, error) {
+	m := make(map[Subscribe]struct{})
+
+	subs, err := GetSubsByUserID(user.TelegramID)
+	if err != nil {
+		return nil, errors.New("get subs error")
+	}
+
+	subsWithSources := make([]*SubWithSource, 0, len(subs))
+	for _, sub := range subs {
+		sub := sub
+		if _, ok := m[sub]; ok {
+			continue
+		}
+		m[sub] = struct{}{}
+		source, err := GetSourceById(sub.SourceID)
+		if err != nil {
+			continue
+		}
+		subsWithSources = append(subsWithSources, &SubWithSource{
+			Sub: &sub,
+			Src: source,
+		})
+	}
+
+	return subsWithSources, nil
+}


### PR DESCRIPTION
optimize for big OPML, to support THE 500+ rss OPML.

1. optimize the big rss import time.
2. fix too long sub list cannot send to tg error.

https://github.com/chainfeeds/RSSAggregatorforWeb3