### PR TITLE
feat: add telegraph includes/excludes

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -83,6 +83,8 @@ allowed_users:
 | --------------------------| ----------------------------------------- | ------------------------------------------ |
 | bot_token                 | Telegram Bot Token                        | 必填                                       |
 | telegraph_token           | Telegraph Token, 用于转存原文到 Telegraph   | 可忽略（不转存原文到 Telegraph ）          |
+| telegraph_includes       | 当此列表不为空时，在此列表的 pattern 才会按照原逻辑尝试转存                 | 可忽略          |
+| telegraph_excludes       | 当 telegraph_includes 为空且此列表不为空时，在此列表的 pattern 不会转存 | 可忽略          |
 | preview_text              | 纯文字预览字数（不借助Telegraph）            |可忽略（默认0, 0为禁用）                    |
 | user_agent                | User Agent                                |可忽略                                     |
 | disable_web_page_preview  | 是否禁用 web 页面预览                       | 可忽略（默认 false, true 为禁用）          |

--- a/internal/config/autoload.go
+++ b/internal/config/autoload.go
@@ -84,6 +84,12 @@ func init() {
 		}
 	}
 
+	if viper.IsSet("telegraph_includes") {
+		TelegraphIncludes = viper.GetStringSlice("telegraph_includes")
+	} else if viper.IsSet("telegraph_excludes") {
+		TelegraphExcludes = viper.GetStringSlice("telegraph_excludes")
+	}
+
 	if viper.IsSet("preview_text") {
 		PreviewText = viper.GetInt("preview_text")
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,8 @@ var (
 	TelegraphAccountName string
 	TelegraphAuthorName  string = "flowerss-bot"
 	TelegraphAuthorURL   string
+	TelegraphIncludes    []string
+	TelegraphExcludes    []string
 
 	// EnableTelegraph 是否启用telegraph
 	EnableTelegraph       bool = false

--- a/internal/model/content.go
+++ b/internal/model/content.go
@@ -33,7 +33,7 @@ func getContentByFeedItem(source *Source, item *rss.Item) (Content, error) {
 	html = strings.Replace(html, "<![CDATA[", "", -1)
 	html = strings.Replace(html, "]]>", "", -1)
 
-	if config.EnableTelegraph && len([]rune(html)) > config.PreviewText {
+	if config.EnableTelegraph && tgraph.Verify(source.Link) && len([]rune(html)) > config.PreviewText {
 		TelegraphURL = PublishItem(source, item, html)
 	}
 

--- a/internal/tgraph/fliter.go
+++ b/internal/tgraph/fliter.go
@@ -1,0 +1,34 @@
+package tgraph
+
+import (
+	"github.com/indes/flowerss-bot/internal/config"
+	"regexp"
+)
+
+func match(pattern, link string) bool {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return false
+	}
+
+	return re.MatchString(link)
+}
+
+func Verify(link string) bool {
+	if len(config.TelegraphIncludes) > 0 {
+		for _, pattern := range config.TelegraphIncludes {
+			if match(pattern, link) {
+				return true
+			}
+		}
+		return false
+	} else if len(config.TelegraphExcludes) > 0 {
+		for _, pattern := range config.TelegraphExcludes {
+			if match(pattern, link) {
+				return false
+			}
+		}
+		return true
+	}
+	return true
+}


### PR DESCRIPTION
例如： `https://github.com/indes.atom`

flowerss-bot 目前连同 `https://github.com/indes/flowerss-bot/compare/9d06a7d399...2775f7af0d` 这样的 link 都会尝试去生成 telegraph，观感不佳，全局关掉又很可惜。

我们可以用正则来排除掉它：

```yaml
telegraph_excludes:
- '^https://github\.com/[^/]+/[^/]+/compare'
```

includes 和 excludes 互斥，都为空则保持原逻辑。

你觉得如何？