### PR TITLE
fix: error with gbk encoding

### DIFF
--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -3,10 +3,7 @@ package fetch
 import (
 	"github.com/SlyMarbo/rss"
 	"github.com/indes/flowerss-bot/pkg/client"
-	"io"
 	"net/http"
-	"strings"
-	"unicode"
 )
 
 // FetchFunc rss fetch func
@@ -16,19 +13,6 @@ func FetchFunc(client *client.HttpClient) rss.FetchFunc {
 		if err != nil {
 			return nil, err
 		}
-		defer resp.Body.Close()
-
-		var data []byte
-		if data, err = io.ReadAll(resp.Body); err != nil {
-			return nil, err
-		}
-
-		resp.Body = io.NopCloser(strings.NewReader(strings.Map(func(r rune) rune {
-			if unicode.IsPrint(r) {
-				return r
-			}
-			return -1
-		}, string(data))))
 		return
 	}
 }


### PR DESCRIPTION
我不太确定这段代码的初衷（似乎是为了处理某些不标准编码导致的乱码？）：

https://github.com/indes/flowerss-bot/blob/5c856b58ad7acb98c8f0525f4c5488f4228b8390/internal/fetch/fetch.go#L19-L31

但是它会导致 encoding 为 gbk 的 feed 出现乱码

```xml
<?xml version="1.0" encoding="gbk"?>
```

简单复现：
```go
f, _ := rss.FetchByFunc(fetch.FetchFunc(client.NewHttpClient(client.WithTimeout(time.Minute))), "https://www.52pojie.cn/forum.php?mod=rss")
fmt.Println(f.Title, f.Description)
```