### PR TITLE
chore: update go version of dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.13-alpine as builder
-#ENV CGO_ENABLED=0
+FROM golang:1.18.6-alpine as builder
+ENV CGO_ENABLED=0
 COPY . /flowerss
-RUN apk add git make gcc libc-dev && \
+RUN apk add git make && \
     cd /flowerss && make build
 
 # Image starts here

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,9 @@ test:
 all: build
 
 build: get
-	go build -ldflags \
-	"-X 'github.com/indes/flowerss-bot/internal/config.commit=$(COMMIT)' \
+	go build -trimpath -ldflags \
+	"-s -w -buildid= \
+	-X 'github.com/indes/flowerss-bot/internal/config.commit=$(COMMIT)' \
 	-X 'github.com/indes/flowerss-bot/internal/config.date=$(DATA)' \
 	-X 'github.com/indes/flowerss-bot/internal/config.version=$(VERSION)'" -o $(app_name)
 


### PR DESCRIPTION
关于编译用的 go 版本选择：
https://go.dev/doc/devel/release#policy

关于移除 CGO 相关：
注意到用了 cgo-free 的 sqlite 库，所以是可以去除的。

关于 build flag：
`-trimpath` 和 `-s -w` 可以缩减体积；
`buildid=` 是为了编译的可重复性，参见 https://github.com/golang/go/issues/34186