### PR TITLE
fix: use cgo sqlite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.18.6-alpine as builder
-ENV CGO_ENABLED=0
+#ENV CGO_ENABLED=0
 COPY . /flowerss
-RUN apk add git make && \
+RUN apk add git make gcc libc-dev && \
     cd /flowerss && make build
 
 # Image starts here

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -63,7 +63,7 @@ func connectDB() {
 	if config.EnableMysql {
 		db, err = gorm.Open("mysql", config.Mysql.GetMysqlConnectingString())
 	} else {
-		db, err = gorm.Open("sqlite", config.SQLitePath)
+		db, err = gorm.Open("sqlite3", config.SQLitePath)
 	}
 	if err != nil {
 		zap.S().Fatalf("connect db failed, err: %+v", err)

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/indes/flowerss-bot/internal/task"
 
 	_ "github.com/jinzhu/gorm/dialects/mysql"
-	_ "modernc.org/sqlite"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
 )
 
 func main() {


### PR DESCRIPTION
modernc.org/sqlite 库存在兼容性问题，会导致新表中第一条数据主键为空，恢复cgo版本的sqlite库